### PR TITLE
Improve minification and add status for "FAILED_DEPENDENCY"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /**
- * Constants enumerating the HTTP status codes. 
- * 
- * All status codes defined in RFC1945 (HTTP/1.0, RFC2616 (HTTP/1.1), 
+ * Constants enumerating the HTTP status codes.
+ *
+ * All status codes defined in RFC1945 (HTTP/1.0, RFC2616 (HTTP/1.1),
  * and RFC2518 (WebDAV) are supported.
  *
  * Based on the org.apache.commons.httpclient.HttpStatus Java API.
@@ -9,110 +9,61 @@
  * Ported by Bryce Neal.
  */
 
-exports.ACCEPTED = 202;
-exports.BAD_GATEWAY = 502;
-exports.BAD_REQUEST = 400;
-exports.CONFLICT = 409;
-exports.CONTINUE = 100;
-exports.CREATED = 201;
-exports.EXPECTATION_FAILED = 417;
-exports.FORBIDDEN = 403;
-exports.GATEWAY_TIMEOUT = 504;
-exports.GONE = 410;
-exports.HTTP_VERSION_NOT_SUPPORTED = 505;
-exports.INSUFFICIENT_SPACE_ON_RESOURCE = 419;
-exports.INSUFFICIENT_STORAGE = 507;
-exports.INTERNAL_SERVER_ERROR = 500;
-exports.LENGTH_REQUIRED = 411;
-exports.LOCKED = 423;
-exports.METHOD_FAILURE = 420;
-exports.METHOD_NOT_ALLOWED = 405;
-exports.MOVED_PERMANENTLY = 301;
-exports.MOVED_TEMPORARILY = 302;
-exports.MULTI_STATUS = 207;
-exports.MULTIPLE_CHOICES = 300;
-exports.NO_CONTENT = 204;
-exports.NON_AUTHORITATIVE_INFORMATION = 203;
-exports.NOT_ACCEPTABLE = 406;
-exports.NOT_FOUND = 404;
-exports.NOT_IMPLEMENTED = 501;
-exports.NOT_MODIFIED = 304;
-exports.OK = 200;
-exports.PARTIAL_CONTENT = 206;
-exports.PAYMENT_REQUIRED = 402;
-exports.PRECONDITION_FAILED = 412;
-exports.PROCESSING = 102;
-exports.PROXY_AUTHENTICATION_REQUIRED = 407;
-exports.REQUEST_TIMEOUT = 408;
-exports.REQUEST_TOO_LONG = 413;
-exports.REQUEST_URI_TOO_LONG = 414;
-exports.REQUESTED_RANGE_NOT_SATISFIABLE = 416;
-exports.RESET_CONTENT = 205;
-exports.SEE_OTHER = 303;
-exports.SERVICE_UNAVAILABLE = 503;
-exports.SWITCHING_PROTOCOLS = 101;
-exports.TEMPORARY_REDIRECT = 307;
-exports.UNAUTHORIZED = 401;
-exports.UNPROCESSABLE_ENTITY = 422;
-exports.UNSUPPORTED_MEDIA_TYPE = 415;
-exports.USE_PROXY = 305;
-
-exports.getStatusText = function(statusCode) {
-	if (statusCodes.hasOwnProperty(statusCode)) {
-		return statusCodes[statusCode];
-	} else {
-		throw "Status code does not exist: " + statusCode;
-		return null;
-	}
-}
-
 var statusCodes = {};
 
-statusCodes[this.ACCEPTED] = "Accepted";
-statusCodes[this.BAD_GATEWAY] = "Bad Gateway";
-statusCodes[this.BAD_REQUEST] = "Bad Request";
-statusCodes[this.CONFLICT] = "Conflict";
-statusCodes[this.CONTINUE] = "Continue";
-statusCodes[this.CREATED] = "Created";
-statusCodes[this.EXPECTATION_FAILED] = "Expectation Failed";
-statusCodes[this.FAILED_DEPENDENCY] = "FailedDependency";
-statusCodes[this.FORBIDDEN] = "Forbidden";
-statusCodes[this.GATEWAY_TIMEOUT] = "Gateway Timeout";
-statusCodes[this.GONE] = "Gone";
-statusCodes[this.HTTP_VERSION_NOT_SUPPORTED] = "HTTP Version Not Supported";
-statusCodes[this.INSUFFICIENT_SPACE_ON_RESOURCE] = "Insufficient Space on Resource";
-statusCodes[this.INSUFFICIENT_STORAGE] = "Insufficient Storage";
-statusCodes[this.INTERNAL_SERVER_ERROR] = "Server Error";
-statusCodes[this.LENGTH_REQUIRED] = "Length Required";
-statusCodes[this.LOCKED] = "Locked";
-statusCodes[this.METHOD_FAILURE] = "Method Failure";
-statusCodes[this.METHOD_NOT_ALLOWED] = "Method Not Allowed";
-statusCodes[this.MOVED_PERMANENTLY] = "Moved Permanently";
-statusCodes[this.MOVED_TEMPORARILY] = "Moved Temporarily";
-statusCodes[this.MULTI_STATUS] = "Multi-Status";
-statusCodes[this.MULTIPLE_CHOICES] = "Multiple Choices";
-statusCodes[this.NO_CONTENT] = "No Content";
-statusCodes[this.NON_AUTHORITATIVE_INFORMATION] = "Non Authoritative Information";
-statusCodes[this.NOT_ACCEPTABLE] = "Not Acceptable";
-statusCodes[this.NOT_FOUND] = "Not Found";
-statusCodes[this.NOT_IMPLEMENTED] = "Not Implemented";
-statusCodes[this.NOT_MODIFIED] = "Not Modified";
-statusCodes[this.OK] = "OK";
-statusCodes[this.PARTIAL_CONTENT] = "Partial Content";
-statusCodes[this.PAYMENT_REQUIRED] = "Payment Required";
-statusCodes[this.PRECONDITION_FAILED] = "Precondition Failed";
-statusCodes[this.PROCESSING] = "Processing";
-statusCodes[this.PROXY_AUTHENTICATION_REQUIRED] = "Proxy Authentication Required";
-statusCodes[this.REQUEST_TIMEOUT] = "Request Timeout";
-statusCodes[this.REQUEST_TOO_LONG] = "Request Entity Too Large";
-statusCodes[this.REQUEST_URI_TOO_LONG] = "Request-URI Too Long";
-statusCodes[this.REQUESTED_RANGE_NOT_SATISFIABLE] = "Requested Range Not Satisfiable";
-statusCodes[this.RESET_CONTENT] = "Reset Content";
-statusCodes[this.SEE_OTHER] = "See Other";
-statusCodes[this.SERVICE_UNAVAILABLE] = "Service Unavailable";
-statusCodes[this.SWITCHING_PROTOCOLS] = "Switching Protocols";
-statusCodes[this.TEMPORARY_REDIRECT] = "Temporary Redirect";
-statusCodes[this.UNAUTHORIZED] = "Unauthorized";
-statusCodes[this.UNPROCESSABLE_ENTITY] = "Unprocessable Entity";
-statusCodes[this.UNSUPPORTED_MEDIA_TYPE] = "Unsupported Media Type";
-statusCodes[this.USE_PROXY] = "Use Proxy";
+statusCodes[exports.ACCEPTED = 202] = "Accepted";
+statusCodes[exports.BAD_GATEWAY = 502] = "Bad Gateway";
+statusCodes[exports.BAD_REQUEST = 400] = "Bad Request";
+statusCodes[exports.CONFLICT = 409] = "Conflict";
+statusCodes[exports.CONTINUE = 100] = "Continue";
+statusCodes[exports.CREATED = 201] = "Created";
+statusCodes[exports.EXPECTATION_FAILED = 417] = "Expectation Failed";
+statusCodes[exports.FAILED_DEPENDENCY  = 424] = "Failed Dependency";
+statusCodes[exports.FORBIDDEN = 403] = "Forbidden";
+statusCodes[exports.GATEWAY_TIMEOUT = 504] = "Gateway Timeout";
+statusCodes[exports.GONE = 410] = "Gone";
+statusCodes[exports.HTTP_VERSION_NOT_SUPPORTED = 505] = "HTTP Version Not Supported";
+statusCodes[exports.INSUFFICIENT_SPACE_ON_RESOURCE = 419] = "Insufficient Space on Resource";
+statusCodes[exports.INSUFFICIENT_STORAGE = 507] = "Insufficient Storage";
+statusCodes[exports.INTERNAL_SERVER_ERROR = 500] = "Server Error";
+statusCodes[exports.LENGTH_REQUIRED = 411] = "Length Required";
+statusCodes[exports.LOCKED = 423] = "Locked";
+statusCodes[exports.METHOD_FAILURE = 420] = "Method Failure";
+statusCodes[exports.METHOD_NOT_ALLOWED = 405] = "Method Not Allowed";
+statusCodes[exports.MOVED_PERMANENTLY = 301] = "Moved Permanently";
+statusCodes[exports.MOVED_TEMPORARILY = 302] = "Moved Temporarily";
+statusCodes[exports.MULTI_STATUS = 207] = "Multi-Status";
+statusCodes[exports.MULTIPLE_CHOICES = 300] = "Multiple Choices";
+statusCodes[exports.NO_CONTENT = 204] = "No Content";
+statusCodes[exports.NON_AUTHORITATIVE_INFORMATION = 203] = "Non Authoritative Information";
+statusCodes[exports.NOT_ACCEPTABLE = 406] = "Not Acceptable";
+statusCodes[exports.NOT_FOUND = 404] = "Not Found";
+statusCodes[exports.NOT_IMPLEMENTED = 501] = "Not Implemented";
+statusCodes[exports.NOT_MODIFIED = 304] = "Not Modified";
+statusCodes[exports.OK = 200] = "OK";
+statusCodes[exports.PARTIAL_CONTENT = 206] = "Partial Content";
+statusCodes[exports.PAYMENT_REQUIRED = 402] = "Payment Required";
+statusCodes[exports.PRECONDITION_FAILED = 412] = "Precondition Failed";
+statusCodes[exports.PROCESSING = 102] = "Processing";
+statusCodes[exports.PROXY_AUTHENTICATION_REQUIRED = 407] = "Proxy Authentication Required";
+statusCodes[exports.REQUEST_TIMEOUT = 408] = "Request Timeout";
+statusCodes[exports.REQUEST_TOO_LONG = 413] = "Request Entity Too Large";
+statusCodes[exports.REQUEST_URI_TOO_LONG = 414] = "Request-URI Too Long";
+statusCodes[exports.REQUESTED_RANGE_NOT_SATISFIABLE = 416] = "Requested Range Not Satisfiable";
+statusCodes[exports.RESET_CONTENT = 205] = "Reset Content";
+statusCodes[exports.SEE_OTHER = 303] = "See Other";
+statusCodes[exports.SERVICE_UNAVAILABLE = 503] = "Service Unavailable";
+statusCodes[exports.SWITCHING_PROTOCOLS = 101] = "Switching Protocols";
+statusCodes[exports.TEMPORARY_REDIRECT = 307] = "Temporary Redirect";
+statusCodes[exports.UNAUTHORIZED = 401] = "Unauthorized";
+statusCodes[exports.UNPROCESSABLE_ENTITY = 422] = "Unprocessable Entity";
+statusCodes[exports.UNSUPPORTED_MEDIA_TYPE = 415] = "Unsupported Media Type";
+statusCodes[exports.USE_PROXY = 305] = "Use Proxy";
+
+exports.getStatusText = function(statusCode) {
+  if (statusCodes.hasOwnProperty(statusCode)) {
+    return statusCodes[statusCode];
+  } else {
+    throw new Error("Status code does not exist: " + statusCode);
+  }
+};


### PR DESCRIPTION
Reduces the min+gz from 1367 bytes to 1200 bytes - for those of use that use this library browser-side :) Also:

* Fixed the status code for `FAILED_DEPENDENCY`. The status text was included, but the status code was missing.
* Dropped the `return null;` since it's unreachable because of the `throw`. 
* `throw` an `Error` so there is a stack trace.